### PR TITLE
Fix Spanish typo in i18n

### DIFF
--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -15,7 +15,7 @@ i18n.use(initReactI18next).init({
         'User is not confirmed.': 'El usuario no ha confirmado su cuenta.',
         PasswordResetRequiredException: 'Restablecimiento de contraseña requerido',
         'Password reset required for the user.': 'Es necesario restablecer la contraseña.',
-        TooManyFailedAttemptsException: 'Demasios intentos fallidos',
+        TooManyFailedAttemptsException: 'Demasiados intentos fallidos',
         'Too many failed attempts, please try again later.':
           'Ha excedido el número de intentos. Intenta de nuevo más tarde.',
         InvalidParameterException: 'Parámetro inválido',


### PR DESCRIPTION
## Summary
- correct Spanish message for TooManyFailedAttemptsException

## Testing
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840559c65f4832198e5063c6c1de068